### PR TITLE
feature: Do a HTTP requests without expect a response

### DIFF
--- a/request.go
+++ b/request.go
@@ -12,9 +12,9 @@ import (
 
 // Requester make a call to server and can assert the returned response with expected one.
 type Requester struct {
-	url         string
-	httpRequest *http.Request
-	response    interface{}
+	url                string
+	httpRequest        *http.Request
+	response           interface{}
 	responseStatusCode int
 }
 
@@ -39,7 +39,7 @@ func (r Requester) Create(jsonPayload string) Requester {
 // Update accept as parameters resource path and payload that you want to send to the server.
 // Create a new http.Request and return the updated Requester.
 func (r Requester) Update(path string, payload interface{}) Requester {
-	b, err :=json.Marshal(payload)
+	b, err := json.Marshal(payload)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func (r Requester) Delete(path string) Requester {
 // Get accept as parameters resource path to the resource that you want to get.
 // Create a new http.Request and return the updated Requester.
 func (r Requester) Get(filters string) Requester {
-	req, err := http.NewRequest(http.MethodGet, r.url + filters, nil)
+	req, err := http.NewRequest(http.MethodGet, r.url+filters, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/v2/request_test.go
+++ b/v2/request_test.go
@@ -38,3 +38,9 @@ func TestRequestWithExpectNil(t *testing.T) {
 		Expect(nil, http.StatusUnauthorized).
 		Call(t)
 }
+
+func TestSendRequestWithoutAssertTheResponse(t *testing.T) {
+	v2.NewRequest(http.MethodGet, "https://api.github.com", "").
+		WithBasicAuth("fooo", "barr").
+		Call(t)
+}


### PR DESCRIPTION
Some times we want only to send a request to the server and we doesn't care about the resposne (success or not).
For that reason we change the type "Request" that only request without assert the result and we created a new
type "RequestExpectant" that can assert expected response from the server.